### PR TITLE
fix: add alternative block device path

### DIFF
--- a/plugin.go
+++ b/plugin.go
@@ -226,14 +226,16 @@ func (d plugin) Mount(r *volume.MountRequest) (*volume.MountResponse, error) {
 	//
 	// Waiting for device appearance
 
-	dev := fmt.Sprintf("/dev/disk/by-id/virtio-%.20s", vol.ID)
-	logger.WithField("dev", dev).Debug("Waiting for device to appear...")
-	err = waitForDevice(dev)
+	logger.Debug("Waiting for device to appear...")
+
+	dev, err := findDeviceWithTimeout(vol.ID)
 
 	if err != nil {
-		logger.WithError(err).Error("Expected block device not found")
-		return nil, fmt.Errorf("Block device not found: %s", dev)
+		logger.WithError(err).Error("Block device not found")
+		return nil, err
 	}
+
+	logger.WithField("dev", dev).Debug("Found device")
 
 	//
 	// Check filesystem and format if necessary


### PR DESCRIPTION
This PR adds support for alternative block device paths. Currently, the driver only searches for virtio block devices which causes the mounting to fail if a different path is used. With this patch, support for scsi devices is added and additional path formats can be added easily if required in the future.