### PR TITLE
chore: update deprecated ioutil function calls

### DIFF
--- a/main.go
+++ b/main.go
@@ -4,7 +4,7 @@ import (
 	"context"
 	"encoding/json"
 	"flag"
-	"io/ioutil"
+	"io"
 	_log "log"
 	"os"
 
@@ -36,7 +36,7 @@ type tConfig struct {
 }
 
 func init() {
-	_log.SetOutput(ioutil.Discard)
+	_log.SetOutput(io.Discard)
 
 	log.SetFormatter(&log.TextFormatter{DisableTimestamp: true})
 	log.SetOutput(os.Stdout)
@@ -60,7 +60,7 @@ func main() {
 	log.SetFormatter(&log.TextFormatter{DisableTimestamp: true})
 	log.SetOutput(os.Stdout)
 
-	content, err := ioutil.ReadFile(configFile)
+	content, err := os.ReadFile(configFile)
 	if err != nil {
 		log.Fatal(err.Error())
 	}

--- a/plugin.go
+++ b/plugin.go
@@ -4,7 +4,6 @@ import (
 	"context"
 	"errors"
 	"fmt"
-	"io/ioutil"
 	"os"
 	"os/exec"
 	"path/filepath"
@@ -46,7 +45,7 @@ func newPlugin(provider *gophercloud.ProviderClient, endpointOpts gophercloud.En
 	}
 
 	if len(config.MachineID) == 0 {
-		bytes, err := ioutil.ReadFile("/etc/machine-id")
+		bytes, err := os.ReadFile("/etc/machine-id")
 		if err != nil {
 			log.WithError(err).Error("Error reading machine id")
 			return nil, err
@@ -346,7 +345,7 @@ func (d plugin) Unmount(r *volume.UnmountRequest) error {
 	path := filepath.Join(d.config.MountDir, r.Name)
 	exists, err := isDirectoryPresent(path)
 	if err != nil {
-		logger.WithError(err).Error("Error checking directory stat: %s", path)
+		logger.WithError(err).Errorf("Error checking directory stat: %s", path)
 	}
 
 	if exists {


### PR DESCRIPTION
This PR replaces deprecated `ioutil` function calls with the corresponding ones in `os` and `io`. It also fixes a warning where a formatted error was used without specifying `Errorf`.